### PR TITLE
Switching to "template" plug-in type.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ fs = require('fs');
 module.exports = BrunchStatic = (function() {
   BrunchStatic.prototype.brunchPlugin = true;
 
-  BrunchStatic.prototype.type = 'stylesheet';
+  BrunchStatic.prototype.type = 'template';
 
   function BrunchStatic(config) {
     var ref, ref1, ref2, ref3, ref4;

--- a/src/brunch-static.coffee
+++ b/src/brunch-static.coffee
@@ -5,15 +5,16 @@ path = require 'path'
 fs = require 'fs'
 
 module.exports = class BrunchStatic
-  # We say we are a "stylesheet" plugin because javascript and template
-  # plugins will append to the javascript file. This is a problem because,
+  # We say we are a "template" plugin because javascript plugins will
+  # append to the javascript file. This is a problem because,
   # if wrapping is enabled (like commonjs), this will cause a bunch of
   # empty crap to be written to the javascript file. Stylesheets, on the
-  # other hand, don't have any wrapping. So, when we return an empty string
-  # to brunch after compiling, this will just result in an empty line in the
-  # css file, which will be removed by minifying anyway. It's a hack =(
+  # other hand, don't have any wrapping but will trigger compilation watchers
+  # as if the CSS has been changed. Instead, templates that return an empty string
+  # to brunch after compiling, this will just result in an unwrapped but empty
+  # line to the JS, which will be removed by minifying anyway. It's a hack =(
   brunchPlugin: true
-  type: 'stylesheet'
+  type: 'template'
 
   constructor: (config) ->
     @outputDir = path.join(path.resolve(process.cwd()), config?.paths?.public or 'public')


### PR DESCRIPTION
Using the "stylesheet" brunch plug-in type, does not emit junk
into compiled javascript, however, it _does_ cause down-stream
`onCompile()` hooks like `auto-reload-brunch` to think that the CSS
has changed, and not the page itself. Which will require a manual refresh...

It appears that the "template" type has been resolved in brunch so that it _no longer_
emits the wrapper if the returned result is empty. It also has a side-effect of triggering
the proper down stream changes for `onCompile()`.
